### PR TITLE
🌱 assorted template gardening

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.wasm32-wasi]
+rustflags = ["-C", "debuginfo=2"]
+
+[build]
+target = "wasm32-wasi"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/README.md @fastly/developer-relations
+/fastly.toml @fastly/developer-relations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 /README.md @fastly/developer-relations
 /fastly.toml @fastly/developer-relations
+*.rs @fastly/ecp-sdk-sme
+/Cargo.toml @fastly/ecp-sdk-sme

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+on: pull_request
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        rust-toolchain: [1.46.0]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+    - name: Add wasm32-wasi Rust target
+      run: rustup target add wasm32-wasi --toolchain ${{ matrix.rust-toolchain }}
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install fmt
+      run: rustup component add rustfmt
+      shell: bash
+    - name: Install clippy
+      run: rustup component add clippy
+      shell: bash
+    - name: Install audit
+      run: cargo install cargo-audit
+      shell: bash
+    - name: fmt
+      run: cargo fmt
+      shell: bash
+    - name: clippy
+      run: cargo clippy
+      shell: bash
+    - name: audit
+      run: cargo audit
+      shell: bash
+    - name: build
+      run: cargo build
+      shell: bash


### PR DESCRIPTION
### 🌱 assorted template gardening

This branch includes a few assorted adjustments to the template. Rather than posting all of these as individual PR's, I felt that it would be easier to bundle these together. In general, these are porting some things that are in the default template, which I believe ought to be included here as well for the sake of parity.

In order, the changes are:

* ec01b14 adds a `.cargo/config` file, so that `--target=wasm32-wasi` need not be manually specified.
* 2e5fd2a adds a github actions script so that we have CI for this repository :sparkles: 
* bf512a4 add a code owners file, so changes can be appropriately reviewed by DevRel members
* 7febeca adds some additional code owners, so code changes can be reviewed by friendly Rustaceans :crab: 
